### PR TITLE
Dart 2.12 compatibility

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -20,7 +20,7 @@ void main(List<String> args) async {
 Future<Report> createReport(DateTime when, Stream<String> lines) async {
   var processor = Processor(timestamp: when);
   await for (String line in lines) {
-    processor.process(json.decode(line) as Map<String, dynamic>);
+    processor.process(json.decode(line) as Map<String, dynamic>?);
   }
   return processor.report;
 }

--- a/lib/src/api/model.dart
+++ b/lib/src/api/model.dart
@@ -11,7 +11,7 @@ class Report {
   final Iterable<Suite> suites;
 
   /// The timestamp of the test. Might be `null`.
-  final DateTime timestamp;
+  final DateTime? timestamp;
 
   /// Create a report with the given [suites] and [timestamp].
   Report(Iterable<Suite> suites, {this.timestamp})
@@ -29,12 +29,12 @@ class Suite {
   static final bool Function(Test t) _hidden = (t) => t.isHidden;
 
   /// The path to the suite's file.
-  final String path;
+  final String? path;
 
   /// The platform on which the suite is running.
   ///
   /// Might be `null`.
-  final String platform;
+  final String? platform;
 
   /// All [Test]s contained by this Suite, including the hidden tests.
   final Iterable<Test> allTests;
@@ -65,7 +65,7 @@ class Suite {
 /// Describes a single Test.
 class Test {
   /// The name of the test, including prefixes from any containing groups.
-  final String name;
+  final String? name;
 
   /// How long did the test take.
   ///
@@ -73,7 +73,7 @@ class Test {
   final int duration;
 
   /// Indicates why was the test skipped.
-  final String skipReason;
+  final String? skipReason;
 
   /// [Problem]s occurred during the test.
   final Iterable<Problem> problems;
@@ -89,7 +89,7 @@ class Test {
   /// Creates a Test with the given [name], [duration], [skipReason],
   /// [problems], [prints] and [isHidden].
   Test(this.name, this.duration, this.skipReason, Iterable<Problem> problems,
-      Iterable<String> prints, this.isHidden)
+      Iterable<String?> prints, this.isHidden)
       : problems = List.unmodifiable(problems),
         prints = List.unmodifiable(prints);
 
@@ -102,10 +102,10 @@ class Test {
 /// Based on [ErrorEvent](https://github.com/dart-lang/test/blob/master/pkgs/test/doc/json_reporter.md#errorevent).
 class Problem {
   /// The result of calling toString() on the error object.
-  final String message;
+  final String? message;
 
   /// The error's stack trace, in the stack_trace package format.
-  final String stacktrace;
+  final String? stacktrace;
 
   /// Whether the error was a TestFailure.
   final bool isFailure;

--- a/lib/src/api/processor.dart
+++ b/lib/src/api/processor.dart
@@ -10,13 +10,13 @@ abstract class Processor {
   Processor._();
 
   /// Creates a Processor for the given [timestamp].
-  factory Processor({DateTime timestamp}) => StartProcessor(timestamp);
+  factory Processor({DateTime? timestamp}) => StartProcessor(timestamp);
 
   /// Processes a single [event](https://github.com/dart-lang/test/blob/master/pkgs/test/doc/json_reporter.md#events).
   ///
   /// Throws a [StateError] is the [StartEvent](https://github.com/dart-lang/test/blob/master/pkgs/test/doc/json_reporter.md#startevent)
   /// is not the first event.
-  void process(Map<String, dynamic> event) {}
+  void process(Map<String, dynamic>? event) {}
 
   /// The report of the handled events so far.
   ///

--- a/lib/src/impl/processor1.dart
+++ b/lib/src/impl/processor1.dart
@@ -9,25 +9,25 @@ import 'package:testreport/src/api/processor.dart';
 class Processor1 implements Processor {
   static const resultCodes = ['success', 'failure', 'error'];
 
-  Map<int, _Suite> suites = SplayTreeMap();
-  Map<int, _Test> tests = <int, _Test>{};
-  final DateTime timestamp;
+  Map<int?, _Suite> suites = SplayTreeMap();
+  Map<int?, _Test> tests = <int?, _Test>{};
+  final DateTime? timestamp;
 
   Processor1(this.timestamp);
 
   @override
-  void process(Map<String, dynamic> event) {
-    var type = event['type'] as String;
+  void process(Map<String, dynamic>? event) {
+    var type = event!['type'] as String?;
     switch (type) {
       case 'testStart':
         var test = event['test'] as Map<String, dynamic>;
         var testCase = _Test()
-          ..startTime = event['time'] as int
-          ..name = test['name'] as String
-          ..skipReason = test['metadata']['skipReason'] as String;
+          ..startTime = event['time'] as int?
+          ..name = test['name'] as String?
+          ..skipReason = test['metadata']['skipReason'] as String?;
 
-        tests[test['id'] as int] = testCase;
-        suites[test['suiteID']].tests.add(testCase);
+        tests[(test['id'] as int?)] = testCase;
+        suites[test['suiteID']]!.tests.add(testCase);
         break;
 
       case 'testDone':
@@ -35,25 +35,25 @@ class Processor1 implements Processor {
           throw ArgumentError("Unknown result in '$event'");
         }
 
-        tests[event['testID'] as int]
-          ..endTime = event['time'] as int
-          ..hidden = event['hidden'] as bool;
+        tests[(event['testID'] as int?)]
+          ?..endTime = event['time'] as int?
+          ..hidden = event['hidden'] as bool?;
         break;
 
       case 'suite':
         var suite = event['suite'] as Map<String, dynamic>;
-        suites[suite['id'] as int] = _Suite()
-          ..path = suite['path'] as String
-          ..platform = suite['platform'] as String;
+        suites[(suite['id'] as int?)] = _Suite()
+          ..path = suite['path'] as String?
+          ..platform = suite['platform'] as String?;
         break;
 
       case 'error':
-        tests[event['testID']].problems.add(Problem(event['error'] as String,
-            event['stackTrace'] as String, event['isFailure'] as bool));
+        tests[event['testID']]!.problems.add(Problem(event['error'] as String?,
+            event['stackTrace'] as String?, event['isFailure'] as bool? ?? true));
         break;
 
       case 'print':
-        tests[event['testID'] as int].prints.add(event['message'] as String);
+        tests[(event['testID'] as int?)]!.prints.add(event['message'] as String?);
         break;
 
       case 'done':
@@ -75,27 +75,27 @@ class Processor1 implements Processor {
 }
 
 class _Test {
-  String name;
-  int startTime;
-  int endTime = unfinished;
-  String skipReason;
+  String? name;
+  int? startTime;
+  int? endTime = unfinished;
+  String? skipReason;
   List<Problem> problems = <Problem>[];
-  List<String> prints = <String>[];
-  bool hidden;
+  List<String?> prints = <String?>[];
+  bool? hidden;
 
   Test toTestCase() => Test(
         name,
-        endTime == unfinished ? unfinished : endTime - startTime,
+        endTime == unfinished ? unfinished : endTime! - startTime!,
         skipReason,
         problems,
         prints,
-        hidden && problems.isEmpty,
+        hidden! && problems.isEmpty,
       );
 }
 
 class _Suite {
-  String path;
-  String platform;
+  String? path;
+  String? platform;
   List<_Test> tests = <_Test>[];
 
   Suite toTestSuite() => Suite(

--- a/lib/src/impl/startprocessor.dart
+++ b/lib/src/impl/startprocessor.dart
@@ -7,14 +7,14 @@ import 'package:testreport/src/api/processor.dart';
 import 'package:testreport/src/impl/processor1.dart';
 
 class StartProcessor implements Processor {
-  Processor _delegate;
-  final DateTime timestamp;
+  Processor? _delegate;
+  final DateTime? timestamp;
 
   StartProcessor(this.timestamp);
 
   @override
-  void process(Map<String, dynamic> event) {
-    var type = event['type'] as String;
+  void process(Map<String, dynamic>? event) {
+    var type = event!['type'] as String?;
     if (type == null) throw ArgumentError("No type in '$event'");
     if (type == 'start') {
       if (_delegate == null) {
@@ -26,13 +26,13 @@ class StartProcessor implements Processor {
     if (_delegate == null) {
       throw StateError('not started');
     }
-    _delegate.process(event);
+    _delegate!.process(event);
   }
 
   @override
   Report get report {
     if (_delegate == null) throw StateError('not started');
-    return _delegate.report;
+    return _delegate!.report;
   }
 
   Processor _createDelegate(String version) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,15 @@
 name: testreport
-version: 1.2.1-dev
+version: 2.0.0-dev
 description: >
   This library can be used to process the results of dart tests.
   It processes data from the `json` output emitted by the dart test runner
   and provide an API to the test results.
 
 homepage: https://github.com/TOPdesk/dart-testreport
-documentation:
-
-dependencies:
 
 dev_dependencies:
   test: any
   pedantic: ^1.9.0
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Running `dart migrate` tool, accepting all changes.

With this change I can get dart-junitreport to work with Dart 2.12.

Note that this also bumps the major version to 2.0.0 which seems to be the norm for null-save libraries.